### PR TITLE
Fixes output file name in update_formula.sh

### DIFF
--- a/update_formula.sh
+++ b/update_formula.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -e -u
 
 BINARY_BASE_URL=$(echo ${BINARY_BASE_URL} | sed 's/\//\\\//g')
 VERSION=$(echo "${VERSION}" | cut -d "v" -f2)

--- a/update_formula.sh
+++ b/update_formula.sh
@@ -6,7 +6,7 @@ BINARY_BASE_URL=$(echo ${BINARY_BASE_URL} | sed 's/\//\\\//g')
 VERSION=$(echo "${VERSION}" | cut -d "v" -f2)
 
 mkdir -p Formula
-cp klotho.rb.tmpl Formula/klotho.rb
+cp klotho.rb.tmpl "Formula/${OUTPUT_FILE_NAME}"
 
 sed -i "s/{{FORMULA_NAME}}/${FORMULA_NAME}/g" Formula/${OUTPUT_FILE_NAME}
 sed -i "s/{{BINARY_BASE_URL}}/${BINARY_BASE_URL}/g" Formula/${OUTPUT_FILE_NAME}


### PR DESCRIPTION
Replaces hardcoded output file name with value of `OUTPUT_FILE_NAME` environment variable to ensure that the correct output file gets created for the formula being generated.