### PR TITLE
Fixes klotho pro download url

### DIFF
--- a/klotho-oss.rb.tmpl
+++ b/klotho-oss.rb.tmpl
@@ -1,0 +1,43 @@
+class
+  {{FORMULA_NAME}} < Formula
+  desc ""
+  homepage "https://klo.dev"
+  license "Apache 2.0"
+  version "{{VERSION}}"
+
+  depends_on "pulumi"
+
+  on_macos do
+    on_arm do
+      url "{{BINARY_BASE_URL}}/v{{VERSION}}/klotho_darwin_arm64"
+      sha256 "{{MACOS_ARM_SHA256}}"
+
+      def install
+        bin.install "klotho_darwin_arm64" => "klotho"
+      end
+    end
+    on_intel do
+      url "{{BINARY_BASE_URL}}/v{{VERSION}}/klotho_darwin_amd64"
+      sha256 "{{MACOS_INTEL_SHA256}}"
+
+      def install
+        bin.install "klotho_darwin_amd64" => "klotho"
+      end
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "{{BINARY_BASE_URL}}/v{{VERSION}}/klotho_linux_amd64"
+      sha256 "{{LINUX_INTEL_SHA256}}"
+
+      def install
+        bin.install "klotho_linux_amd64" => "klotho"
+      end
+    end
+  end
+
+  test do
+    system "klotho", "--version"
+  end
+end

--- a/klotho.rb.tmpl
+++ b/klotho.rb.tmpl
@@ -1,3 +1,15 @@
+require "download_strategy"
+
+class KlothoDownloadStrategy < CurlDownloadStrategy
+  def initialize(url, name, version, **meta)
+    super
+  end
+
+  def parse_basename(url, search_query: true)
+    # automatically rename the downloaded binary to klotho since the server doesn't provide a filename
+    "klotho"
+  end
+
 class
   {{FORMULA_NAME}} < Formula
   desc ""
@@ -7,33 +19,25 @@ class
 
   depends_on "pulumi"
 
+  def install
+    bin.install "klotho"
+  end
+
   on_macos do
     on_arm do
-      url "{{BINARY_BASE_URL}}/v{{VERSION}}/klotho_darwin_arm64"
+      url "http://srv.klo.dev/update/latest/darwin/arm64?stream=pro:v{{VERSION}}", :using => KlothoDownloadStrategy
       sha256 "{{MACOS_ARM_SHA256}}"
-
-      def install
-        bin.install "klotho_darwin_arm64" => "klotho"
-      end
     end
     on_intel do
-      url "{{BINARY_BASE_URL}}/v{{VERSION}}/klotho_darwin_amd64"
+      url "http://srv.klo.dev/update/latest/darwin/x86_64?stream=pro:v{{VERSION}}", :using => KlothoDownloadStrategy
       sha256 "{{MACOS_INTEL_SHA256}}"
-
-      def install
-        bin.install "klotho_darwin_amd64" => "klotho"
-      end
     end
   end
 
   on_linux do
     on_intel do
-      url "{{BINARY_BASE_URL}}/v{{VERSION}}/klotho_linux_amd64"
+      url "http://srv.klo.dev/update/latest/linux/x86_64?stream=pro:v{{VERSION}}", :using => KlothoDownloadStrategy
       sha256 "{{LINUX_INTEL_SHA256}}"
-
-      def install
-        bin.install "klotho_linux_amd64" => "klotho"
-      end
     end
   end
 

--- a/update_formula.sh
+++ b/update_formula.sh
@@ -7,7 +7,7 @@ VERSION=$(echo "${VERSION}" | cut -d "v" -f2)
 OUTPUT_PATH="Formula/${OUTPUT_FILE_NAME}"
 
 mkdir -p Formula
-cp klotho.rb.tmpl $OUTPUT_PATH
+cp "${OUTPUT_FILE_NAME}.tmpl" $OUTPUT_PATH
 
 sed -i "s/{{FORMULA_NAME}}/${FORMULA_NAME}/g" $OUTPUT_PATH
 sed -i "s/{{BINARY_BASE_URL}}/${BINARY_BASE_URL}/g" $OUTPUT_PATH


### PR DESCRIPTION
- Splits formula templates for oss and pro
- Updates the update script to use formula-specific templates
- Updates the klotho-oss template to inlcude and Apache 2.0 license
- Sets the download url for pro to the klotho update server